### PR TITLE
Add time unit to config durations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,6 +245,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "futures",
+ "rand 0.8.5",
  "reqwest",
  "temp-env",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ reqwest = { version = "0.11" }
 tokio = { version = "1", features = ["full"] }
 futures = "0.3.29"
 warp = "0.3.6"
+rand = "0.8.5"
 
 [dev-dependencies]
 wiremock = "0.5"

--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ depends_on:
 You can configure the health checker with the following environment variables:
 
 * `HOSTS`: A comma-separated list of URLs.
-* `TIMEOUT`: The timeout duration in milliseconds for each HTTP GET request e.g. 2000 represents a 2-second timeout.
+* `TIMEOUT`: The timeout duration for each HTTP GET request e.g. `500ms`, `1s`.
 * `RETRIES`: The maximum number of HTTP requests sent to each URL before it is marked as unhealthy.
-* `INTERVAL`: The time interval in milliseconds between consecutive HTTP requests to each URL. Example: 1000 for 1 second.
+* `INTERVAL`: The time interval in milliseconds between consecutive HTTP requests to each URL e.g. `2s`.
 
 ### Image Link
 Check out the image on [dockerhub](https://hub.docker.com/r/malooooch/distroless-hc).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
         http://test-server2:3031/healthcheck,
         http://test-server3:3032/healthcheck
       RETRIES: 10
+      INTERVAL: 2s
+      TIMEOUT: 3s
     depends_on:
       - test-server1
       - test-server2
@@ -21,6 +23,7 @@ services:
     environment:
       - PORT=3030
       - FAIL_COUNT=4
+      - RESPONSE_DELAY=2500
     # Can't use a typical healthcheck for distroless containers.
     # The following won't work:
     # healthcheck:
@@ -35,6 +38,7 @@ services:
       dockerfile: Dockerfile-testserver
     environment:
       - PORT=3031
+      - RESPONSE_DELAY=1500
       - FAIL_COUNT=9
 
   test-server3:
@@ -43,3 +47,5 @@ services:
       dockerfile: Dockerfile-testserver
     environment:
       - PORT=3032
+      - RESPONSE_DELAY=4000
+      - FAIL_COUNT=5

--- a/src/config/dur.rs
+++ b/src/config/dur.rs
@@ -2,54 +2,51 @@ use std::num::ParseIntError;
 use std::str::FromStr;
 use std::time::Duration;
 
-fn parse_duration(val: &str) -> Result<Duration, ParseDurError> {
-    let idx = val
-        .find(|c: char| !c.is_digit(10))
-        .ok_or(ParseDurError::MissingUnit)?;
-
-    let (num, unit) = val.split_at(idx);
-
-    let num: u64 = num.parse()?;
-    let unit: Unit = unit.parse()?;
-
-    Ok(to_duration(num, unit))
+pub enum TimeUnit {
+    Nanos(u64),
+    Micros(u64),
+    Millis(u64),
+    Secs(u64),
+    Mins(u64),
 }
 
-fn to_duration(num: u64, unit: Unit) -> Duration {
-    match unit {
-        Unit::Nanos => Duration::from_nanos(num),
-        Unit::Micros => Duration::from_micros(num),
-        Unit::Millis => Duration::from_millis(num),
-        Unit::Secs => Duration::from_secs(num),
-        Unit::Mins => Duration::from_secs(num * 60),
+impl From<TimeUnit> for Duration {
+    fn from(unit: TimeUnit) -> Duration {
+        match unit {
+            TimeUnit::Nanos(num) => Duration::from_nanos(num),
+            TimeUnit::Micros(num) => Duration::from_micros(num),
+            TimeUnit::Millis(num) => Duration::from_millis(num),
+            TimeUnit::Secs(num) => Duration::from_secs(num),
+            TimeUnit::Mins(num) => Duration::from_secs(num * 60),
+        }
     }
 }
 
-enum Unit {
-    Nanos,
-    Micros,
-    Millis,
-    Secs,
-    Mins,
-}
-
-impl FromStr for Unit {
+impl FromStr for TimeUnit {
     type Err = ParseDurError;
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "ns" => Ok(Unit::Nanos),
-            "us" => Ok(Unit::Micros),
-            "ms" => Ok(Unit::Millis),
-            "s" => Ok(Unit::Secs),
-            "m" => Ok(Unit::Mins),
+    fn from_str(val: &str) -> Result<Self, Self::Err> {
+        let idx = val
+            .find(|c: char| !c.is_digit(10))
+            .ok_or(ParseDurError::MissingUnit)?;
+
+        let (num, unit) = val.split_at(idx);
+
+        let num: u64 = num.parse()?;
+
+        match unit {
+            "ns" => Ok(TimeUnit::Nanos(num)),
+            "us" => Ok(TimeUnit::Micros(num)),
+            "ms" => Ok(TimeUnit::Millis(num)),
+            "s" => Ok(TimeUnit::Secs(num)),
+            "m" => Ok(TimeUnit::Mins(num)),
             _ => Err(ParseDurError::InvalidUnit),
         }
     }
 }
 
 #[derive(Debug)]
-enum ParseDurError {
+pub enum ParseDurError {
     MissingUnit,
     InvalidNum(ParseIntError),
     InvalidUnit,

--- a/src/config/dur.rs
+++ b/src/config/dur.rs
@@ -1,0 +1,74 @@
+use std::num::ParseIntError;
+use std::str::FromStr;
+use std::time::Duration;
+
+fn parse_duration(val: &str) -> Result<Duration, ParseDurError> {
+    let idx = val
+        .find(|c: char| !c.is_digit(10))
+        .ok_or(ParseDurError::MissingUnit)?;
+
+    let (num, unit) = val.split_at(idx);
+
+    let num: u64 = num.parse()?;
+    let unit: Unit = unit.parse()?;
+
+    Ok(to_duration(num, unit))
+}
+
+fn to_duration(num: u64, unit: Unit) -> Duration {
+    match unit {
+        Unit::Nanos => Duration::from_nanos(num),
+        Unit::Micros => Duration::from_micros(num),
+        Unit::Millis => Duration::from_millis(num),
+        Unit::Secs => Duration::from_secs(num),
+        Unit::Mins => Duration::from_secs(num * 60),
+    }
+}
+
+enum Unit {
+    Nanos,
+    Micros,
+    Millis,
+    Secs,
+    Mins,
+}
+
+impl FromStr for Unit {
+    type Err = ParseDurError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ns" => Ok(Unit::Nanos),
+            "us" => Ok(Unit::Micros),
+            "ms" => Ok(Unit::Millis),
+            "s" => Ok(Unit::Secs),
+            "m" => Ok(Unit::Mins),
+            _ => Err(ParseDurError::InvalidUnit),
+        }
+    }
+}
+
+#[derive(Debug)]
+enum ParseDurError {
+    MissingUnit,
+    InvalidNum(ParseIntError),
+    InvalidUnit,
+}
+
+impl std::error::Error for ParseDurError {}
+
+impl std::fmt::Display for ParseDurError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ParseDurError::MissingUnit => write!(f, "Duration unit is missing"),
+            ParseDurError::InvalidNum(e) => write!(f, "{}", e),
+            ParseDurError::InvalidUnit => write!(f, "Duration unit is in valid"),
+        }
+    }
+}
+
+impl From<ParseIntError> for ParseDurError {
+    fn from(err: ParseIntError) -> Self {
+        ParseDurError::InvalidNum(err)
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -32,7 +32,7 @@ impl Config {
             .parse()
             .context("RETRIES is not a valid number")?;
 
-        let interval: TimeUnit = env::var("TIMEOUT")
+        let interval: TimeUnit = env::var("INTERVAL")
             .unwrap_or(DEFAULT_INTERVAL.to_string())
             .parse()
             .context("INTERVAL is not a valid number")?;
@@ -74,9 +74,9 @@ mod tests {
         temp_env::with_vars(
             [
                 ("HOSTS", Some(" host1, host2, host3")),
-                ("TIMEOUT", Some("500")),
+                ("TIMEOUT", Some("500ms")),
                 ("RETRIES", Some("3")),
-                ("INTERVAL", Some("1500")),
+                ("INTERVAL", Some("2s")),
             ],
             || {
                 let config = Config::from_env().unwrap();
@@ -90,7 +90,7 @@ mod tests {
                 );
                 assert_eq!(config.timeout, Duration::from_millis(500));
                 assert_eq!(config.retries, 3);
-                assert_eq!(config.interval, Duration::from_millis(1500));
+                assert_eq!(config.interval, Duration::from_secs(2));
             },
         );
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4,10 +4,11 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 
 mod dur;
+use dur::TimeUnit;
 
-const DEFAULT_TIMEOUT: &str = "1000";
+const DEFAULT_TIMEOUT: &str = "1s";
 const DEFAULT_RETRIES: &str = "5";
-const DEFAULT_INTERVAL: &str = "1000";
+const DEFAULT_INTERVAL: &str = "1s";
 
 #[derive(Debug)]
 pub struct Config {
@@ -21,7 +22,7 @@ impl Config {
     pub fn from_env() -> Result<Self> {
         let hosts = env::var("HOSTS").context("Missing HOSTS environment variable")?;
 
-        let timeout = env::var("TIMEOUT")
+        let timeout: TimeUnit = env::var("TIMEOUT")
             .unwrap_or(DEFAULT_TIMEOUT.to_string())
             .parse()
             .context("TIMEOUT is not a valid number")?;
@@ -31,16 +32,16 @@ impl Config {
             .parse()
             .context("RETRIES is not a valid number")?;
 
-        let interval = env::var("INTERVAL")
+        let interval: TimeUnit = env::var("TIMEOUT")
             .unwrap_or(DEFAULT_INTERVAL.to_string())
             .parse()
             .context("INTERVAL is not a valid number")?;
 
         Ok(Config {
             hosts: hosts.split(',').map(|s| s.trim().to_string()).collect(),
-            timeout: Duration::from_millis(timeout),
+            timeout: timeout.into(),
             retries,
-            interval: Duration::from_millis(interval),
+            interval: interval.into(),
         })
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3,6 +3,8 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 
+mod dur;
+
 const DEFAULT_TIMEOUT: &str = "1000";
 const DEFAULT_RETRIES: &str = "5";
 const DEFAULT_INTERVAL: &str = "1000";

--- a/src/test_server/server.rs
+++ b/src/test_server/server.rs
@@ -2,7 +2,9 @@ use std::env;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
+use rand;
 use tokio::signal::unix::{signal, SignalKind};
+use tokio::time::{self, Duration};
 use warp::http::status::StatusCode;
 use warp::Filter;
 
@@ -18,6 +20,11 @@ async fn main() {
         .parse()
         .expect("FAIL_COUNT should be a valid number");
 
+    let response_delay: u64 = env::var("RESPONSE_DELAY")
+        .unwrap_or("0".to_string())
+        .parse()
+        .expect("RESPONSE_DELAY should be a valid number");
+
     println!(
         "Running the sever on port {} with fail count {}",
         port, fail_count
@@ -25,14 +32,24 @@ async fn main() {
 
     let num_reqs = Arc::new(AtomicUsize::new(0));
 
-    let health_check = warp::path("healthcheck").map(move || {
-        println!("Received a request");
-        let reqs = num_reqs.fetch_add(1, Ordering::Relaxed) + 1;
-        if reqs >= fail_count {
-            StatusCode::ACCEPTED
-        } else {
-            StatusCode::INTERNAL_SERVER_ERROR
-        }
+    let health_check = warp::path("healthcheck").then(move || {
+        let num_reqs = num_reqs.clone();
+
+        return async move {
+            println!("Received a request");
+
+            if response_delay > 0 {
+                let delay = rand::random::<u64>() % response_delay;
+                time::sleep(Duration::from_millis(delay)).await;
+            }
+
+            let reqs = num_reqs.fetch_add(1, Ordering::Relaxed) + 1;
+            if reqs >= fail_count {
+                StatusCode::ACCEPTED
+            } else {
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
+        };
     });
 
     let shutdown_signal = async {


### PR DESCRIPTION
So that user will be able to specify time duration in a simpler way than just specifying a value in milliseconds.
With this change `INTERVAL` and `TIMEOUT` can be configured with values such as `500ms`, `2s` and `1m`.